### PR TITLE
feat: Add MkDocs documentation and GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+      - master
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,48 @@
+# Architecture
+
+## Core Components
+
+#### **Importers** (`kultivator/importers/`)
+- **MockImporter**: For testing and examples
+- **LogseqEDNImporter**: Parses Logseq EDN/JSON exports
+- *Extensible*: Add new importers for other note-taking apps
+
+#### **AI Agents** (`kultivator/agents/`)
+- **Triage Agent**: Extracts entities and creates summaries
+- **Synthesizer Agent**: Generates and updates wiki content
+- **Agent Registry**: Centralized configuration system
+
+#### **Database** (`kultivator/database/`)
+- **DuckDB-based**: Fast, serverless SQL database
+- **Entity tracking**: Stores discovered entities and relationships
+- **Change detection**: SHA-256 hashing for efficient updates
+
+#### **Versioning** (`kultivator/versioning/`)
+- **Git integration**: Automatic commits and version tracking
+- **Atomic updates**: Each entity change is a separate commit
+
+## Data Flow
+
+```
+Notes → Importer → CanonicalBlock → Triage Agent → Entities
+                                                       ↓
+Wiki ← Synthesizer Agent ← Database ← Entity Processing
+```
+
+## Agent Architecture
+
+Kultivator uses a sophisticated AI agent system:
+
+1. **Triage Agent**:
+   - Reads note blocks
+   - Identifies entities (people, projects, etc.)
+   - Creates summaries
+
+2. **Synthesizer Agent**:
+   - Has access to database tools
+   - Can query related entities for context
+   - Generates rich, cross-referenced content
+
+3. **Database Tools**:
+   - `list_entities(type)`: Get entities by type
+   - `get_entity_context(name)`: Get mention history

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,20 @@
+# Configuration
+
+Kultivator is configured using the `config.yaml` file.
+
+## AI Settings
+- `ai.ollama_host`: Ollama server URL
+- `ai.model`: Model name (gemma3, llama3.2, etc.)
+- `ai.timeout`: Request timeout in seconds
+
+## Database Settings
+- `database.filename`: DuckDB database file
+- `database.timeout`: Database operation timeout
+
+## Wiki Settings
+- `wiki.file_extension`: File extension for wiki pages
+- `wiki.entity_directories`: Mapping of entity types to directories
+
+## Git Settings
+- `git.auto_commit`: Enable automatic commits
+- `git.commit_messages`: Templates for commit messages

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Welcome to Kultivator
+
+**An Automated Knowledge Synthesis Engine**
+
+Kultivator is an intelligent system that connects to hierarchical note-taking applications, processes your notes using local AI, and cultivates them into a structured, cross-referenced wiki. Think of it as your personal knowledge gardener that helps your ideas grow and interconnect.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,32 @@
+# Installation
+
+## Prerequisites
+
+1. **Python 3.10+**
+2. **Ollama** with a compatible model (e.g., gemma3, llama3.2)
+3. **Git** (for versioning)
+
+## Installation Steps
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/Codium-ai/kultivator
+   cd kultivator
+   ```
+
+2. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Start Ollama** (if not already running):
+   ```bash
+   ollama serve
+   ```
+
+4. **Pull a compatible model:**
+   ```bash
+   ollama pull gemma3
+   # or
+   ollama pull llama3.2
+   ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: Kultivator
+theme:
+  name: material
+repo_url: https://github.com/Codium-ai/kultivator
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Configuration: configuration.md
+  - Architecture: architecture.md


### PR DESCRIPTION
- Add MkDocs for documentation.
- Create initial documentation for installation, configuration, and architecture.
- Add a GitHub Action to deploy the documentation to GitHub Pages.